### PR TITLE
Use String instead of URL for authorizationURL

### DIFF
--- a/Sources/OAuth2/AuthProviders/Facebook.swift
+++ b/Sources/OAuth2/AuthProviders/Facebook.swift
@@ -51,7 +51,7 @@ public class Facebook: OAuth2 {
 	*/
 	public init(clientID: String, clientSecret: String) {
 		let tokenURL = "https://graph.facebook.com/v2.3/oauth/access_token"
-		let authorizationURL = URL(string: "https://www.facebook.com/dialog/oauth")!
+		let authorizationURL = "https://www.facebook.com/dialog/oauth"
 		super.init(clientID: clientID, clientSecret: clientSecret, authorizationURL: authorizationURL, tokenURL: tokenURL)
 	}
 

--- a/Sources/OAuth2/AuthProviders/GitHub.swift
+++ b/Sources/OAuth2/AuthProviders/GitHub.swift
@@ -50,7 +50,7 @@ public class GitHub: OAuth2 {
 	*/
 	public init(clientID: String, clientSecret: String) {
 		let tokenURL = "https://github.com/login/oauth/access_token"
-		let authorizationURL = URL(string: "https://github.com/login/oauth/authorize")!
+		let authorizationURL = "https://github.com/login/oauth/authorize"
 		super.init(clientID: clientID, clientSecret: clientSecret, authorizationURL: authorizationURL, tokenURL: tokenURL)
 	}
 

--- a/Sources/OAuth2/AuthProviders/Google.swift
+++ b/Sources/OAuth2/AuthProviders/Google.swift
@@ -55,7 +55,7 @@ public class Google: OAuth2 {
 	*/
 	public init(clientID: String, clientSecret: String) {
 		let tokenURL = "https://www.googleapis.com/oauth2/v4/token"
-		let authorizationURL = URL(string: "https://accounts.google.com/o/oauth2/auth")!
+		let authorizationURL = "https://accounts.google.com/o/oauth2/auth"
 		super.init(clientID: clientID, clientSecret: clientSecret, authorizationURL: authorizationURL, tokenURL: tokenURL)
 	}
 

--- a/Sources/OAuth2/AuthProviders/Linkedin.swift
+++ b/Sources/OAuth2/AuthProviders/Linkedin.swift
@@ -40,7 +40,7 @@ public class Linkedin: OAuth2 {
 	*/
 	public init(clientID: String, clientSecret: String) {
 		let tokenURL = "https://www.linkedin.com/oauth/v2/accessToken"
-		let authorizationURL = URL(string: "https://www.linkedin.com/oauth/v2/authorization")!
+		let authorizationURL = "https://www.linkedin.com/oauth/v2/authorization"
 		super.init(clientID: clientID, clientSecret: clientSecret, authorizationURL: authorizationURL, tokenURL: tokenURL)
 	}
 

--- a/Sources/OAuth2/AuthProviders/Slack.swift
+++ b/Sources/OAuth2/AuthProviders/Slack.swift
@@ -40,7 +40,7 @@ public class Slack: OAuth2 {
 	*/
 	public init(clientID: String, clientSecret: String) {
 		let tokenURL = "https://slack.com/api/oauth.access"
-		let authorizationURL = URL(string: "https://slack.com/oauth/authorize")!
+		let authorizationURL = "https://slack.com/oauth/authorize"
 		super.init(clientID: clientID, clientSecret: clientSecret, authorizationURL: authorizationURL, tokenURL: tokenURL)
 	}
 

--- a/Sources/OAuth2/OAuth2.swift
+++ b/Sources/OAuth2/OAuth2.swift
@@ -24,13 +24,13 @@ open class OAuth2 {
     public let clientSecret: String
     
     /// The Authorization Endpoint of the OAuth 2 Server
-    public let authorizationURL: URL
+    public let authorizationURL: String
     
     /// The Token Endpoint of the OAuth 2 Server
     public let tokenURL: String
     
     /// Creates the OAuth 2 client
-    public init(clientID: String, clientSecret: String, authorizationURL: URL, tokenURL: String) {
+    public init(clientID: String, clientSecret: String, authorizationURL: String, tokenURL: String) {
         self.clientID = clientID
         self.clientSecret = clientSecret
         self.authorizationURL = authorizationURL


### PR DESCRIPTION
Because on Linux getLoginLink didn't work due to:
`var url = "\(authorizationURL)?response_type=code"`

URL to String conversion doesn't work on Linux and I didn't see any reason of using an URL instead of a String