### PR TITLE
added support for refreshing an access token

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,11 +7,11 @@ let package = Package(
 			name: "OAuth2"),
 		],
     dependencies: [
-		.Package(url: "https://github.com/PerfectlySoft/PerfectLib.git", majorVersion: 2),
-		.Package(url: "https://github.com/PerfectlySoft/Perfect-HTTP.git", majorVersion: 2),
-		.Package(url: "https://github.com/PerfectlySoft/Perfect-Logger.git", majorVersion: 1),
+		.Package(url: "https://github.com/PerfectlySoft/PerfectLib.git", majorVersion: 3),
+		.Package(url: "https://github.com/PerfectlySoft/Perfect-HTTP.git", majorVersion: 3),
+		.Package(url: "https://github.com/PerfectlySoft/Perfect-Logger.git", majorVersion: 3),
 		.Package(url: "https://github.com/iamjono/SwiftString.git", majorVersion: 2),
-		.Package(url: "https://github.com/PerfectlySoft/Perfect-Session.git", majorVersion: 1),
+		.Package(url: "https://github.com/PerfectlySoft/Perfect-Session.git", majorVersion: 3),
 		]
 
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
 		.Package(url: "https://github.com/PerfectlySoft/PerfectLib.git", majorVersion: 2),
 		.Package(url: "https://github.com/PerfectlySoft/Perfect-HTTP.git", majorVersion: 2),
 		.Package(url: "https://github.com/PerfectlySoft/Perfect-Logger.git", majorVersion: 1),
-		.Package(url: "https://github.com/iamjono/SwiftString.git", majorVersion: 1),
+		.Package(url: "https://github.com/iamjono/SwiftString.git", majorVersion: 2),
 		.Package(url: "https://github.com/PerfectlySoft/Perfect-Session.git", majorVersion: 1),
 		]
 

--- a/Sources/OAuth2/OAuth2Error.swift
+++ b/Sources/OAuth2/OAuth2Error.swift
@@ -24,7 +24,7 @@ public struct OAuth2Error: Error {
     }
     
     /// Convenience initializer from JSON
-    init?(json: [String: Any]) {
+    public init?(json: [String: Any]) {
         guard let errorCode = json["error"] as? String,
               let code = OAuth2ErrorCode(rawValue: errorCode) else {
                 return nil

--- a/Sources/OAuth2/makeRequest.swift
+++ b/Sources/OAuth2/makeRequest.swift
@@ -23,7 +23,7 @@ extension OAuth2 {
 	/// - body: The JSON formatted sring to sent to the server
 	/// Response:
 	/// (HTTPResponseStatus, "data" - [String:Any], "raw response" - [String:Any], HTTPHeaderParser)
-	func makeRequest(
+	open func makeRequest(
 		_ method: HTTPMethod,
 		_ url: String,
 		body: String = "",

--- a/Tests/AuthTests/AuthProvidersTests.swift
+++ b/Tests/AuthTests/AuthProvidersTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AuthProviders
+@testable import OAuth2
 
 class AuthProvidersTests: XCTestCase {
 


### PR DESCRIPTION
There you go. A support for renewing the access token. In an ideal situation the demo should check for the `expiry` date against `now` and renew the access token using the stored refresh token.  


P.S. I tried testing with GitHub, but they don't return a refresh token as far as I found 😞 