### PR TITLE
Fix crash with Github auth when name is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      env: JOB=SwiftPM_OSX SWIFT_VERSION=3.1
+      osx_image: xcode8.3
+
+    - os: linux
+      env: JOB=SwiftPM_linux SWIFT_VERSION=3.1
+      dist: trusty
+      sudo: required
+      before_install:
+       - sudo apt-get install openssl libssl-dev uuid-dev
+       - sudo apt-get install libcurl4-openssl-dev
+
+install:
+  -  travis_retry eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+
+script:
+  - swift build
+

--- a/Sources/OAuth2/AuthProviders/GitHub.swift
+++ b/Sources/OAuth2/AuthProviders/GitHub.swift
@@ -70,8 +70,7 @@ public class GitHub: OAuth2 {
 		if let n = data["id"] {
 			out["userid"] = "\(n)"
 		}
-		if let n = data["name"] {
-			let nn = n as! String
+		if let n = data["name"], let nn = n as? String {
 			let nnn = nn.split(" ")
 			if nnn.count > 0 {
 				out["first_name"] = nnn.first

--- a/Sources/OAuth2/AuthProviders/Google.swift
+++ b/Sources/OAuth2/AuthProviders/Google.swift
@@ -91,7 +91,7 @@ public class Google: OAuth2 {
 
 	/// Google-specific exchange function
 	public func exchange(request: HTTPRequest, state: String) throws -> OAuth2Token {
-		let token = try exchange(request: request, state: state, redirectURL: "\(GoogleConfig.endpointAfterAuth)?session=\((request.session?.token)!)")
+		let token = try exchange(request: request, state: state, redirectURL: "\(GoogleConfig.endpointAfterAuth)")
 
 		if let domain = GoogleConfig.restrictedDomain {
 			guard let hd = token.webToken?["hd"] as? String, hd == domain else {
@@ -104,7 +104,7 @@ public class Google: OAuth2 {
 
 	/// Google-specific login link
 	public func getLoginLink(state: String, request: HTTPRequest, scopes: [String] = ["profile"]) -> String {
-		var url = getLoginLink(redirectURL: "\(GoogleConfig.endpointAfterAuth)?session=\((request.session?.token)!)", state: state, scopes: scopes)
+		var url = getLoginLink(redirectURL: "\(GoogleConfig.endpointAfterAuth)", state: state, scopes: scopes)
 		if let domain = GoogleConfig.restrictedDomain {
 			url += "&hd=\(domain)"
 		}


### PR DESCRIPTION
A GitHub account may have no name set in which case the force cast to String here caused a crash.