### PR TITLE
Fix Github auth crash by avoiding force cast.

### DIFF
--- a/Sources/OAuth2/AuthProviders/GitHub.swift
+++ b/Sources/OAuth2/AuthProviders/GitHub.swift
@@ -70,8 +70,7 @@ public class GitHub: OAuth2 {
 		if let n = data["id"] {
 			out["userid"] = "\(n)"
 		}
-		if let n = data["name"] {
-			let nn = n as! String
+		if let n = data["name"], let nn = n as? String {			
 			let nnn = nn.split(" ")
 			if nnn.count > 0 {
 				out["first_name"] = nnn.first


### PR DESCRIPTION
Github accounts may have a null name property thus crashing with the force cast.